### PR TITLE
Fix star rating

### DIFF
--- a/apps/web/src/components/StarRating.svelte
+++ b/apps/web/src/components/StarRating.svelte
@@ -2,19 +2,12 @@
   export let rating: number = 3;
 </script>
 
-<label class="leading-none">
-  <div class="rating relative">
-    {#each [1, 2, 3, 4, 5] as n}
-      <p class="absolute h-0 opacity-0">{n}</p>
-      <input
-        type="radio"
-        name="rating"
-        class="mask mask-star cursor-auto bg-orange-400"
-        value={n}
-        bind:group={rating}
-        readonly
-        disabled
-      />
-    {/each}
-  </div>
-</label>
+<div class="rating">
+  {#each [1, 2, 3, 4, 5] as n}
+    <div
+      class="mask mask-star bg-orange-400"
+      aria-label="{n} star"
+      aria-current={n === rating ? "true" : "false"}
+    />
+  {/each}
+</div>


### PR DESCRIPTION
Star rating broken since upgrading daisy UI. There is a new recommendation on how to do accessible read-only ratings from the docs [here](https://daisyui.com/components/rating/#read-only-rating) which has been followed.